### PR TITLE
ps-exe not starting due to invalid exe t_size

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -443,7 +443,7 @@ bool System::loadExeFile(const std::vector<uint8_t>& _exe) {
 
     if (exe.t_size > _exe.size() - 0x800) {
         fmt::print("Invalid exe t_size: 0x{:08x}\n", exe.t_size);
-        return false;
+        exe.t_size = _exe.size() - 0x800;
     }
 
     for (uint32_t i = 0; i < exe.t_size; i++) {


### PR DESCRIPTION
This change allows to run several demo programs that work on hardware, but didn't start in Avocado before, including:

- http://www.pouet.net/prod.php?which=33355
- http://www.pouet.net/prod.php?which=49450
- http://www.pouet.net/prod.php?which=49030